### PR TITLE
doc: fix link leading to 404

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,5 +236,5 @@ hidden layers.
 Under the hood, this package uses the [Rubix ML](https://rubixml.com/) library.
 This means you can use any estimator is supports.
 
-See the [Choosing an Estimator](https://docs.rubixml.com/en/latest/choosing-an-estimator.html)
+See the [Choosing an Estimator](https://docs.rubixml.com/latest/choosing-an-estimator.html)
 page for a list of all available estimators you can use for attribute prediction.


### PR DESCRIPTION
Hi,

The existing link is not working and causing 404